### PR TITLE
Add setup script for .NET SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # NewRepo
+
+This repository contains a .NET application.
+
+To install the .NET SDK required to build the project, run the setup script:
+
+```bash
+./setup.sh
+```

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+# Install the Microsoft package repository
+apt-get update
+apt-get install -y wget apt-transport-https
+wget https://packages.microsoft.com/config/ubuntu/24.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+sudo dpkg -i packages-microsoft-prod.deb
+rm packages-microsoft-prod.deb
+
+# Install the .NET SDK
+apt-get update
+apt-get install -y dotnet-sdk-8.0
+
+echo "Installed .NET SDK"


### PR DESCRIPTION
## Summary
- add setup.sh to install the .NET SDK via apt-get
- document the script in README

## Testing
- `dotnet --version` *(fails: command not found)*
- `dotnet build DhanAlgoTrading.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ef207fc30832184ac0c6c77dd3f57