### PR TITLE
Add .NET SDK setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
-# NewRepo
+# DhanAlgoTrading
+
+This repository contains an ASP.NET application targeting **.NET 8.0**.
+
+## Development environment setup
+
+Run the provided `setup.sh` script to install the required .NET SDK. The script
+is intended for Debian/Ubuntu environments and requires `sudo` privileges.
+
+```bash
+./setup.sh
+```
+
+The script checks for an existing .NET 8 installation and installs it from the
+Microsoft package repository when missing.
+
+## Building the project
+
+After installing the SDK, restore dependencies and build the solution:
+
+```bash
+dotnet restore
+
+dotnet build
+```
+

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -e
+
+REQUIRED_MAJOR_VERSION=8
+
+if command -v dotnet >/dev/null 2>&1; then
+    INSTALLED_VERSION=$(dotnet --version | cut -d. -f1)
+    if [ "$INSTALLED_VERSION" = "$REQUIRED_MAJOR_VERSION" ]; then
+        echo ".NET SDK $REQUIRED_MAJOR_VERSION is already installed."
+        exit 0
+    fi
+fi
+
+# Install .NET SDK 8.0 on Debian/Ubuntu
+sudo apt-get update
+sudo apt-get install -y wget apt-transport-https
+wget https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+sudo dpkg -i packages-microsoft-prod.deb
+rm packages-microsoft-prod.deb
+sudo apt-get update
+sudo apt-get install -y dotnet-sdk-8.0
+


### PR DESCRIPTION
## Summary
- add `setup.sh` to install .NET SDK 8
- expand README with instructions for the setup script

## Testing
- `./setup.sh` *(fails: `apt-get` requires network access)*

------
https://chatgpt.com/codex/tasks/task_e_683ef1c2bb88832180591c50c10a085a