### PR TITLE
Fix invalid base URL for user profile requests

### DIFF
--- a/DhanAlgoTrading/Services/DhanService.cs
+++ b/DhanAlgoTrading/Services/DhanService.cs
@@ -62,7 +62,8 @@ namespace DhanAlgoTrading.Api.Services
             // **ASSUMPTION**: Endpoint for User Profile Status. Replace with actual endpoint if known.
             // The PDF mentions a "User Profile API" [cite: 266] but doesn't specify the exact GET endpoint.
             // This is a hypothetical endpoint.
-            var requestUri = $"{_apiSettings.BaseUrl}user/status"; // OR WHATEVER THE ACTUAL ENDPOINT IS
+            // Build the request relative to the configured BaseAddress
+            var requestUri = "/user/status"; // OR WHATEVER THE ACTUAL ENDPOINT IS
 
             try
             {


### PR DESCRIPTION
## Summary
- build the user profile request path relative to the configured base address
- check the requested URI in unit tests

## Testing
- `dotnet test --no-build` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f1dc76ee483219f7b9971799dbaec