### PR TITLE
Implement order update event forwarding

### DIFF
--- a/DhanAlgoTrading.Tests/LiveOrderUpdateServiceTests.cs
+++ b/DhanAlgoTrading.Tests/LiveOrderUpdateServiceTests.cs
@@ -1,0 +1,53 @@
+using DhanAlgoTrading.Models.Configuration;
+using DhanAlgoTrading.Models.DhanApi;
+using DhanAlgoTrading.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace DhanAlgoTrading.Tests
+{
+    public class LiveOrderUpdateServiceTests
+    {
+        private static LiveOrderUpdateService CreateService()
+        {
+            var options = Options.Create(new DhanApiSettings
+            {
+                LiveOrderUpdateUrl = "wss://example",
+                AccessToken = "token",
+                ClientId = "cid"
+            });
+
+            return new LiveOrderUpdateService(NullLogger<LiveOrderUpdateService>.Instance, options);
+        }
+
+        [Fact]
+        public void ProcessMessage_ValidOrderAlert_RaisesEvent()
+        {
+            var service = CreateService();
+            OrderUpdateDataDto? received = null;
+            service.OrderUpdateReceived += (_, d) => received = d;
+
+            const string json = "{\"Data\":{\"OrderNo\":\"ORD123\",\"Status\":\"COMPLETE\",\"Symbol\":\"INFY\",\"TxnType\":\"BUY\",\"Quantity\":10,\"Price\":100.5,\"TradedQty\":10,\"AvgTradedPrice\":100.5},\"Type\":\"order_alert\"}";
+
+            service.ProcessMessage(json);
+
+            Assert.NotNull(received);
+            Assert.Equal("ORD123", received?.OrderNo);
+        }
+
+        [Fact]
+        public void ProcessMessage_InvalidType_DoesNotRaiseEvent()
+        {
+            var service = CreateService();
+            bool fired = false;
+            service.OrderUpdateReceived += (_, _) => fired = true;
+
+            const string json = "{\"Data\":{\"OrderNo\":\"O1\"},\"Type\":\"other\"}";
+
+            service.ProcessMessage(json);
+
+            Assert.False(fired);
+        }
+    }
+}

--- a/DhanAlgoTrading/DhanAlgoTrading.csproj
+++ b/DhanAlgoTrading/DhanAlgoTrading.csproj
@@ -10,5 +10,9 @@
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="9.0.5" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
   </ItemGroup>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo(&quot;DhanAlgoTrading.Tests&quot;)" />
+  </ItemGroup>
  
 </Project>


### PR DESCRIPTION
## Summary
- publish `OrderUpdateReceived` event and add message processing helper
- forward parsed WebSocket updates via event
- expose internals to test project
- add unit tests for event forwarding

## Testing
- `dotnet test DhanAlgoTrading.Tests/DhanAlgoTrading.Tests.csproj -v normal` *(fails: Unable to load the service index for source https://api.nuget.org/v3/index.json)*

------
https://chatgpt.com/codex/tasks/task_e_683f35f56a9883218dfb220f356f03dc