### PR TITLE
Load sensitive settings from env

### DIFF
--- a/DhanAlgoTrading/appsettings.json
+++ b/DhanAlgoTrading/appsettings.json
@@ -9,8 +9,8 @@
   "DhanApiSettings": {
     "BaseUrl": "https://api.dhan.co",
     "LiveOrderUpdateUrl": "wss://api-order-update.dhan.co",
-    "AccessToken": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJkaGFuIiwicGFydG5lcklkIjoiIiwiZXhwIjoxNzUwODQ5NzUzLCJ0b2tlbkNvbnN1bWVyVHlwZSI6IlNFTEYiLCJ3ZWJob29rVXJsIjoiIiwiZGhhbkNsaWVudElkIjoiMTEwNjg4MjcwNyJ9.xyBodUY7sRObgiQMX7y1qj0wFR357XaaZE0EFpWgT4q3JMlH-V56r5tWdzMki71i_aGdh_mY9Zh-F1r2bocpbg",
-    "TradingViewWebhookPassphrase": "YourSuperSecretAndUniquePassphrase123!",
-    "ClientId": "1106882707"
+    "AccessToken": "YOUR_DHAN_ACCESS_TOKEN_HERE",
+    "TradingViewWebhookPassphrase": "YOUR_WEBHOOK_PASSPHRASE_HERE",
+    "ClientId": "YOUR_DHAN_CLIENT_ID_HERE"
   }
 }

--- a/README.md
+++ b/README.md
@@ -40,6 +40,24 @@ dotnet restore
 dotnet build
 ```
 
+## Configuration
+
+The API reads sensitive Dhan credentials from environment variables or user secrets. Set these keys before running:
+
+| Environment Variable | Purpose |
+|----------------------|---------|
+| `DHAN_ACCESS_TOKEN`  | Access token for authenticated API calls |
+| `DHAN_CLIENT_ID`     | Your Dhan client identifier |
+| `TRADINGVIEW_WEBHOOK_PASSPHRASE` | Passphrase expected by the webhook endpoint |
+
+When using user secrets:
+
+```bash
+dotnet user-secrets set DHAN_ACCESS_TOKEN "<token>"
+dotnet user-secrets set DHAN_CLIENT_ID "<client id>"
+dotnet user-secrets set TRADINGVIEW_WEBHOOK_PASSPHRASE "<passphrase>"
+```
+
 ## Run the API
 
 Start the web API from the project directory:


### PR DESCRIPTION
## Summary
- remove real tokens from `appsettings.json`
- read `DhanApiSettings` values from env vars or user secrets
- document configuration env vars in `README`

## Testing
- `dotnet test` *(fails: CS1003 error)*

------
https://chatgpt.com/codex/tasks/task_e_683f42b2473c83219f853102cba4f88d