### PR TITLE
Fix user profile endpoint

### DIFF
--- a/DhanAlgoTrading.Tests/DhanServiceTests.cs
+++ b/DhanAlgoTrading.Tests/DhanServiceTests.cs
@@ -84,7 +84,7 @@ namespace DhanAlgoTrading.Tests
 
             await service.GetUserProfileAsync();
 
-            Assert.Equal("https://api.test/user/status", handler.CapturedRequest?.RequestUri?.ToString());
+            Assert.Equal("https://api.test/profile", handler.CapturedRequest?.RequestUri?.ToString());
         }
     }
 }

--- a/DhanAlgoTrading/DhanAlgoTrading.csproj
+++ b/DhanAlgoTrading/DhanAlgoTrading.csproj
@@ -12,7 +12,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo(&quot;DhanAlgoTrading.Tests&quot;)" />
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>DhanAlgoTrading.Tests</_Parameter1>
+    </AssemblyAttribute>
   </ItemGroup>
  
 </Project>

--- a/DhanAlgoTrading/Services/DhanService.cs
+++ b/DhanAlgoTrading/Services/DhanService.cs
@@ -58,11 +58,11 @@ namespace DhanAlgoTrading.Api.Services
         {
             _logger.LogInformation("GetUserProfileAsync called.");
 
-            // **ASSUMPTION**: Endpoint for User Profile Status. Replace with actual endpoint if known.
-            // The PDF mentions a "User Profile API" [cite: 266] but doesn't specify the exact GET endpoint.
-            // This is a hypothetical endpoint.
-            // Build the request relative to the configured BaseAddress
-            var requestUri = "/user/status"; // OR WHATEVER THE ACTUAL ENDPOINT IS
+            // Endpoint for retrieving the logged in user's profile details.
+            // According to DhanHQ API documentation the profile information is
+            // available via GET /profile. The BaseAddress is configured from
+            // settings so we only provide the relative path here.
+            var requestUri = "/profile";
 
             try
             {


### PR DESCRIPTION
## Summary
- point `GetUserProfileAsync` at the official `/profile` endpoint
- fix InternalsVisibleTo attribute syntax
- update tests to expect `/profile`

## Testing
- `dotnet test DhanAlgoTrading.sln`

------
https://chatgpt.com/codex/tasks/task_e_683f430c31008321a579267fe8b7d8bb