### PR TITLE
Add user profile DTO and update service

### DIFF
--- a/DhanAlgoTrading.Tests/DhanServiceTests.cs
+++ b/DhanAlgoTrading.Tests/DhanServiceTests.cs
@@ -86,5 +86,27 @@ namespace DhanAlgoTrading.Tests
 
             Assert.Equal("https://api.test/profile", handler.CapturedRequest?.RequestUri?.ToString());
         }
+
+        [Fact]
+        public async Task GetUserProfileAsync_DeserializesDto()
+        {
+            var json = "{\"dhanClientId\":\"CID\",\"tokenValidity\":\"valid\",\"activeSegment\":\"NSE_EQ\",\"ddpi\":\"ACTIVE\",\"dataPlan\":\"BASIC\"}";
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(json)
+            };
+
+            var httpClient = new HttpClient(new FakeHandler(response))
+            {
+                BaseAddress = new Uri("https://api.test/")
+            };
+            var settings = Options.Create(new DhanApiSettings { BaseUrl = "https://api.test/", ClientId = "cid", AccessToken = "token" });
+            var service = new DhanService(httpClient, settings, NullLogger<DhanService>.Instance);
+
+            var result = await service.GetUserProfileAsync();
+
+            Assert.Equal("CID", result?.DhanClientId);
+            Assert.Equal("BASIC", result?.DataPlan);
+        }
     }
 }

--- a/DhanAlgoTrading.Tests/TradingViewWebhookControllerTests.cs
+++ b/DhanAlgoTrading.Tests/TradingViewWebhookControllerTests.cs
@@ -16,7 +16,7 @@ namespace DhanAlgoTrading.Tests
     {
         private class StubDhanService : IDhanService
         {
-            public Task<DhanUserProfileStatusDto?> GetUserProfileAsync() => Task.FromResult<DhanUserProfileStatusDto?>(null);
+            public Task<DhanUserProfileDto?> GetUserProfileAsync() => Task.FromResult<DhanUserProfileDto?>(null);
             public Task<IEnumerable<string>> GetExpiryDatesAsync(ExpiryListRequestDto expiryRequest) => Task.FromResult<IEnumerable<string>>(new List<string>());
             public Task<IEnumerable<OptionInstrument>> GetOptionChainAsync(OptionChainRequestDto optionChainRequest) => Task.FromResult<IEnumerable<OptionInstrument>>(new List<OptionInstrument>());
             public Task<OrderResponseDto?> PlaceOrderAsync(OrderRequestDto orderRequest) => Task.FromResult<OrderResponseDto?>(null);

--- a/DhanAlgoTrading/Models/DhanApi/DhanUserProfileDto.cs
+++ b/DhanAlgoTrading/Models/DhanApi/DhanUserProfileDto.cs
@@ -1,0 +1,22 @@
+using System.Text.Json.Serialization;
+
+namespace DhanAlgoTrading.Models.DhanApi
+{
+    public class DhanUserProfileDto
+    {
+        [JsonPropertyName("dhanClientId")]
+        public string? DhanClientId { get; set; }
+
+        [JsonPropertyName("tokenValidity")]
+        public string? TokenValidity { get; set; }
+
+        [JsonPropertyName("activeSegment")]
+        public string? ActiveSegment { get; set; }
+
+        [JsonPropertyName("ddpi")]
+        public string? Ddpi { get; set; }
+
+        [JsonPropertyName("dataPlan")]
+        public string? DataPlan { get; set; }
+    }
+}

--- a/DhanAlgoTrading/Services/DhanService.cs
+++ b/DhanAlgoTrading/Services/DhanService.cs
@@ -54,7 +54,7 @@ namespace DhanAlgoTrading.Api.Services
         }
 
         // Retrieves the logged in user's profile information
-        public async Task<DhanUserProfileStatusDto?> GetUserProfileAsync()
+        public async Task<DhanUserProfileDto?> GetUserProfileAsync()
         {
             _logger.LogInformation("GetUserProfileAsync called.");
 
@@ -89,13 +89,13 @@ namespace DhanAlgoTrading.Api.Services
 
                         // Deserialize to our DTO
                         var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
-                        DhanUserProfileStatusDto? profileStatus = JsonSerializer.Deserialize<DhanUserProfileStatusDto>(responseContent, options);
+                        DhanUserProfileDto? profileStatus = JsonSerializer.Deserialize<DhanUserProfileDto>(responseContent, options);
 
                         if (profileStatus != null)
                         {
                             // Format the DTO into a string to match your method's return signature.
                             // You could also return the JSON string directly: return responseContent;
-                            // Or, ideally, change the method signature to return Task<DhanUserProfileStatusDto?>
+                            // Or, ideally, change the method signature to return Task<DhanUserProfileDto?>
                             // and handle the object in the calling code.
                             return profileStatus;
                         }

--- a/DhanAlgoTrading/Services/IDhanService.cs
+++ b/DhanAlgoTrading/Services/IDhanService.cs
@@ -4,7 +4,7 @@ namespace DhanAlgoTrading.Services
 {
     public interface IDhanService
     {
-        Task<DhanUserProfileStatusDto?> GetUserProfileAsync(); // From Part 1
+        Task<DhanUserProfileDto?> GetUserProfileAsync();
         Task<IEnumerable<string>> GetExpiryDatesAsync(ExpiryListRequestDto expiryRequest); // From Part 2
         Task<IEnumerable<OptionInstrument>> GetOptionChainAsync(OptionChainRequestDto optionChainRequest); // From Part 2
         Task<OrderResponseDto?> PlaceOrderAsync(OrderRequestDto orderRequest); // Method for Part 3


### PR DESCRIPTION
## Summary
- add a `DhanUserProfileDto` to capture `/profile` fields
- return `DhanUserProfileDto` from `GetUserProfileAsync`
- update interface and tests for new DTO
- test DTO deserialization

## Testing
- `dotnet test DhanAlgoTrading.Tests/DhanAlgoTrading.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6840408a421c8321bef3ab79c807e43f