### PR TITLE
Implement missing DhanHQ API methods

### DIFF
--- a/DhanAlgoTrading.Tests/DhanServiceAdditionalTests.cs
+++ b/DhanAlgoTrading.Tests/DhanServiceAdditionalTests.cs
@@ -172,5 +172,36 @@ namespace DhanAlgoTrading.Tests
 
             Assert.Null(result);
         }
+
+        [Fact]
+        public async Task GetHoldingsAsync_ReturnsList()
+        {
+            var json = "[{}]";
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(json, Encoding.UTF8, "application/json")
+            };
+            var httpClient = new HttpClient(new FakeHandler(response)) { BaseAddress = new Uri("https://api.test/") };
+            var settings = Options.Create(new DhanApiSettings { BaseUrl = "https://api.test/", ClientId = "cid", AccessToken = "token" });
+            var service = new DhanService(httpClient, settings, NullLogger<DhanService>.Instance);
+
+            var result = await service.GetHoldingsAsync();
+
+            Assert.Single(result);
+        }
+
+        [Fact]
+        public async Task ConvertPositionAsync_ReturnsTrueOnSuccess()
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.Accepted);
+            var httpClient = new HttpClient(new FakeHandler(response)) { BaseAddress = new Uri("https://api.test/") };
+            var settings = Options.Create(new DhanApiSettings { BaseUrl = "https://api.test/", ClientId = "cid", AccessToken = "token" });
+            var service = new DhanService(httpClient, settings, NullLogger<DhanService>.Instance);
+
+            var req = new ConvertPositionRequestDto { FromProductType = "INTRADAY", ToProductType = "CNC" };
+            var result = await service.ConvertPositionAsync(req);
+
+            Assert.True(result);
+        }
     }
 }

--- a/DhanAlgoTrading.Tests/TradingViewWebhookControllerTests.cs
+++ b/DhanAlgoTrading.Tests/TradingViewWebhookControllerTests.cs
@@ -36,6 +36,11 @@ namespace DhanAlgoTrading.Tests
             public Task<MarketFullQuoteResponseDto?> GetFullMarketQuoteAsync(MarketDataRequestDto request) => Task.FromResult<MarketFullQuoteResponseDto?>(null);
             public Task<IEnumerable<DhanInstrumentDto>> GetInstrumentsBySegmentAsync(string exchangeSegment) => Task.FromResult<IEnumerable<DhanInstrumentDto>>(new List<DhanInstrumentDto>());
             public Task<IEnumerable<OrderResponseDto>?> PlaceSliceOrderAsync(OrderRequestDto sliceOrderRequest) => Task.FromResult<IEnumerable<OrderResponseDto>?>(null);
+            public Task<IEnumerable<DhanHoldingDto>> GetHoldingsAsync() => Task.FromResult<IEnumerable<DhanHoldingDto>>(new List<DhanHoldingDto>());
+            public Task<bool> CancelOrderAsync(string orderId) => Task.FromResult(false);
+            public Task<OrderResponseDto?> ModifyOrderAsync(string orderId, ModifyOrderRequestDto modifyRequest) => Task.FromResult<OrderResponseDto?>(null);
+            public Task<OrderDataDto?> GetOrderByCorrelationIdAsync(string correlationId) => Task.FromResult<OrderDataDto?>(null);
+            public Task<bool> ConvertPositionAsync(ConvertPositionRequestDto convertRequest) => Task.FromResult(false);
         }
 
         [Fact]

--- a/DhanAlgoTrading/Models/DhanApi/ConvertPositionRequestDto.cs
+++ b/DhanAlgoTrading/Models/DhanApi/ConvertPositionRequestDto.cs
@@ -1,0 +1,31 @@
+using System.Text.Json.Serialization;
+
+namespace DhanAlgoTrading.Models.DhanApi
+{
+    public class ConvertPositionRequestDto
+    {
+        [JsonPropertyName("dhanClientId")]
+        public string? DhanClientId { get; set; }
+
+        [JsonPropertyName("fromProductType")]
+        public string? FromProductType { get; set; }
+
+        [JsonPropertyName("exchangeSegment")]
+        public string? ExchangeSegment { get; set; }
+
+        [JsonPropertyName("positionType")]
+        public string? PositionType { get; set; }
+
+        [JsonPropertyName("securityId")]
+        public string? SecurityId { get; set; }
+
+        [JsonPropertyName("tradingSymbol")]
+        public string? TradingSymbol { get; set; }
+
+        [JsonPropertyName("convertQty")]
+        public int ConvertQty { get; set; }
+
+        [JsonPropertyName("toProductType")]
+        public string? ToProductType { get; set; }
+    }
+}

--- a/DhanAlgoTrading/Models/DhanApi/DhanHoldingDto.cs
+++ b/DhanAlgoTrading/Models/DhanApi/DhanHoldingDto.cs
@@ -1,0 +1,18 @@
+using System.Text.Json.Serialization;
+
+namespace DhanAlgoTrading.Models.DhanApi
+{
+    public class DhanHoldingDto
+    {
+        [JsonPropertyName("exchange")] public string? Exchange { get; set; }
+        [JsonPropertyName("tradingSymbol")] public string? TradingSymbol { get; set; }
+        [JsonPropertyName("securityId")] public string? SecurityId { get; set; }
+        [JsonPropertyName("isin")] public string? Isin { get; set; }
+        [JsonPropertyName("totalQty")] public int TotalQty { get; set; }
+        [JsonPropertyName("dpQty")] public int DpQty { get; set; }
+        [JsonPropertyName("t1Qty")] public int T1Qty { get; set; }
+        [JsonPropertyName("availableQty")] public int AvailableQty { get; set; }
+        [JsonPropertyName("collateralQty")] public int CollateralQty { get; set; }
+        [JsonPropertyName("avgCostPrice")] public decimal AvgCostPrice { get; set; }
+    }
+}

--- a/DhanAlgoTrading/Models/DhanApi/ModifyOrderRequestDto.cs
+++ b/DhanAlgoTrading/Models/DhanApi/ModifyOrderRequestDto.cs
@@ -1,0 +1,34 @@
+using System.Text.Json.Serialization;
+
+namespace DhanAlgoTrading.Models.DhanApi
+{
+    public class ModifyOrderRequestDto
+    {
+        [JsonPropertyName("dhanClientId")]
+        public string? DhanClientId { get; set; }
+
+        [JsonPropertyName("orderId")]
+        public string? OrderId { get; set; }
+
+        [JsonPropertyName("orderType")]
+        public string? OrderType { get; set; }
+
+        [JsonPropertyName("legName")]
+        public string? LegName { get; set; }
+
+        [JsonPropertyName("quantity")]
+        public int? Quantity { get; set; }
+
+        [JsonPropertyName("price")]
+        public decimal? Price { get; set; }
+
+        [JsonPropertyName("disclosedQuantity")]
+        public int? DisclosedQuantity { get; set; }
+
+        [JsonPropertyName("triggerPrice")]
+        public decimal? TriggerPrice { get; set; }
+
+        [JsonPropertyName("validity")]
+        public string? Validity { get; set; }
+    }
+}

--- a/DhanAlgoTrading/Services/IDhanService.cs
+++ b/DhanAlgoTrading/Services/IDhanService.cs
@@ -27,6 +27,13 @@ namespace DhanAlgoTrading.Services
         Task<IEnumerable<DhanInstrumentDto>> GetInstrumentsBySegmentAsync(string exchangeSegment);
         Task<IEnumerable<OrderResponseDto>?> PlaceSliceOrderAsync(OrderRequestDto sliceOrderRequest);
 
+        // Newly added methods from remaining API endpoints
+        Task<IEnumerable<DhanHoldingDto>> GetHoldingsAsync();
+        Task<bool> CancelOrderAsync(string orderId);
+        Task<OrderResponseDto?> ModifyOrderAsync(string orderId, ModifyOrderRequestDto modifyRequest);
+        Task<OrderDataDto?> GetOrderByCorrelationIdAsync(string correlationId);
+        Task<bool> ConvertPositionAsync(ConvertPositionRequestDto convertRequest);
+
 
 
     }


### PR DESCRIPTION
## Summary
- add DTOs for holdings, order modification and position conversion
- extend `IDhanService` with new API methods
- implement the new methods in `DhanService`
- adjust tests and service stubs for updated interface

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6840474b70bc832184eb389ede61d417