### PR TITLE
Add missing Dhan API endpoints

### DIFF
--- a/DhanAlgoTrading.Tests/DhanServiceAdditionalTests.cs
+++ b/DhanAlgoTrading.Tests/DhanServiceAdditionalTests.cs
@@ -203,5 +203,39 @@ namespace DhanAlgoTrading.Tests
 
             Assert.True(result);
         }
+
+        [Fact]
+        public async Task GetForeverOrdersAsync_ReturnsList()
+        {
+            var json = "[{\"orderId\":\"1\"}]";
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(json, Encoding.UTF8, "application/json")
+            };
+            var httpClient = new HttpClient(new FakeHandler(response)) { BaseAddress = new Uri("https://api.test/") };
+            var settings = Options.Create(new DhanApiSettings { BaseUrl = "https://api.test/", ClientId = "cid", AccessToken = "token" });
+            var service = new DhanService(httpClient, settings, NullLogger<DhanService>.Instance);
+
+            var result = await service.GetForeverOrdersAsync();
+
+            Assert.Single(result);
+        }
+
+        [Fact]
+        public async Task GenerateEdisTpinAsync_ReturnsDto()
+        {
+            var json = "{\"tpin\":\"1234\"}";
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(json, Encoding.UTF8, "application/json")
+            };
+            var httpClient = new HttpClient(new FakeHandler(response)) { BaseAddress = new Uri("https://api.test/") };
+            var settings = Options.Create(new DhanApiSettings { BaseUrl = "https://api.test/", ClientId = "cid", AccessToken = "token" });
+            var service = new DhanService(httpClient, settings, NullLogger<DhanService>.Instance);
+
+            var result = await service.GenerateEdisTpinAsync();
+
+            Assert.Equal("1234", result?.Tpin);
+        }
     }
 }

--- a/DhanAlgoTrading.Tests/TradingViewWebhookControllerTests.cs
+++ b/DhanAlgoTrading.Tests/TradingViewWebhookControllerTests.cs
@@ -41,6 +41,16 @@ namespace DhanAlgoTrading.Tests
             public Task<OrderResponseDto?> ModifyOrderAsync(string orderId, ModifyOrderRequestDto modifyRequest) => Task.FromResult<OrderResponseDto?>(null);
             public Task<OrderDataDto?> GetOrderByCorrelationIdAsync(string correlationId) => Task.FromResult<OrderDataDto?>(null);
             public Task<bool> ConvertPositionAsync(ConvertPositionRequestDto convertRequest) => Task.FromResult(false);
+            public Task<IEnumerable<ForeverOrderDto>> GetForeverOrdersAsync() => Task.FromResult<IEnumerable<ForeverOrderDto>>(new List<ForeverOrderDto>());
+            public Task<OrderResponseDto?> PlaceForeverOrderAsync(ForeverOrderRequestDto request) => Task.FromResult<OrderResponseDto?>(null);
+            public Task<bool> CancelForeverOrderAsync(string orderId) => Task.FromResult(false);
+            public Task<EdisTpinResponseDto?> GenerateEdisTpinAsync() => Task.FromResult<EdisTpinResponseDto?>(null);
+            public Task<bool> SubmitEdisFormAsync(EdisFormRequestDto form) => Task.FromResult(false);
+            public Task<EdisInquireResponseDto?> InquireEdisAsync(string isin) => Task.FromResult<EdisInquireResponseDto?>(null);
+            public Task<KillSwitchResponseDto?> SetKillSwitchAsync(string status) => Task.FromResult<KillSwitchResponseDto?>(null);
+            public Task<IEnumerable<LedgerEntryDto>> GetLedgerAsync() => Task.FromResult<IEnumerable<LedgerEntryDto>>(new List<LedgerEntryDto>());
+            public Task<IEnumerable<HistoricalTradeDto>> GetHistoricalTradesAsync(string fromDate, string toDate, int page) => Task.FromResult<IEnumerable<HistoricalTradeDto>>(new List<HistoricalTradeDto>());
+            public Task<HistoricalChartResponseDto?> GetHistoricalChartAsync(HistoricalChartRequestDto request) => Task.FromResult<HistoricalChartResponseDto?>(null);
         }
 
         [Fact]

--- a/DhanAlgoTrading/Models/DhanApi/EdisFormRequestDto.cs
+++ b/DhanAlgoTrading/Models/DhanApi/EdisFormRequestDto.cs
@@ -1,0 +1,11 @@
+using System.Text.Json.Serialization;
+
+namespace DhanAlgoTrading.Models.DhanApi
+{
+    public class EdisFormRequestDto
+    {
+        [JsonPropertyName("isin")] public string? Isin { get; set; }
+        [JsonPropertyName("qty")] public int Quantity { get; set; }
+        [JsonPropertyName("tpin")] public string? Tpin { get; set; }
+    }
+}

--- a/DhanAlgoTrading/Models/DhanApi/EdisInquireResponseDto.cs
+++ b/DhanAlgoTrading/Models/DhanApi/EdisInquireResponseDto.cs
@@ -1,0 +1,11 @@
+using System.Text.Json.Serialization;
+
+namespace DhanAlgoTrading.Models.DhanApi
+{
+    public class EdisInquireResponseDto
+    {
+        [JsonPropertyName("isin")] public string? Isin { get; set; }
+        [JsonPropertyName("status")] public string? Status { get; set; }
+        [JsonPropertyName("quantity")] public int Quantity { get; set; }
+    }
+}

--- a/DhanAlgoTrading/Models/DhanApi/EdisTpinResponseDto.cs
+++ b/DhanAlgoTrading/Models/DhanApi/EdisTpinResponseDto.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Serialization;
+
+namespace DhanAlgoTrading.Models.DhanApi
+{
+    public class EdisTpinResponseDto
+    {
+        [JsonPropertyName("tpin")] public string? Tpin { get; set; }
+        [JsonPropertyName("validTill")] public string? ValidTill { get; set; }
+    }
+}

--- a/DhanAlgoTrading/Models/DhanApi/ForeverOrderDto.cs
+++ b/DhanAlgoTrading/Models/DhanApi/ForeverOrderDto.cs
@@ -1,0 +1,14 @@
+using System.Text.Json.Serialization;
+
+namespace DhanAlgoTrading.Models.DhanApi
+{
+    public class ForeverOrderDto
+    {
+        [JsonPropertyName("orderId")] public string? OrderId { get; set; }
+        [JsonPropertyName("status")] public string? Status { get; set; }
+        [JsonPropertyName("securityId")] public string? SecurityId { get; set; }
+        [JsonPropertyName("quantity")] public int Quantity { get; set; }
+        [JsonPropertyName("price")] public decimal? Price { get; set; }
+        [JsonPropertyName("triggerPrice")] public decimal? TriggerPrice { get; set; }
+    }
+}

--- a/DhanAlgoTrading/Models/DhanApi/ForeverOrderRequestDto.cs
+++ b/DhanAlgoTrading/Models/DhanApi/ForeverOrderRequestDto.cs
@@ -1,0 +1,16 @@
+using System.Text.Json.Serialization;
+
+namespace DhanAlgoTrading.Models.DhanApi
+{
+    public class ForeverOrderRequestDto
+    {
+        [JsonPropertyName("transactionType")] public string? TransactionType { get; set; }
+        [JsonPropertyName("exchangeSegment")] public string? ExchangeSegment { get; set; }
+        [JsonPropertyName("orderType")] public string? OrderType { get; set; }
+        [JsonPropertyName("securityId")] public string? SecurityId { get; set; }
+        [JsonPropertyName("quantity")] public int Quantity { get; set; }
+        [JsonPropertyName("price")] public decimal? Price { get; set; }
+        [JsonPropertyName("triggerPrice")] public decimal? TriggerPrice { get; set; }
+        [JsonPropertyName("validity")] public string? Validity { get; set; }
+    }
+}

--- a/DhanAlgoTrading/Models/DhanApi/HistoricalChartRequestDto.cs
+++ b/DhanAlgoTrading/Models/DhanApi/HistoricalChartRequestDto.cs
@@ -1,0 +1,13 @@
+using System.Text.Json.Serialization;
+
+namespace DhanAlgoTrading.Models.DhanApi
+{
+    public class HistoricalChartRequestDto
+    {
+        [JsonPropertyName("securityId")] public string? SecurityId { get; set; }
+        [JsonPropertyName("exchangeSegment")] public string? ExchangeSegment { get; set; }
+        [JsonPropertyName("fromDate")] public string? FromDate { get; set; }
+        [JsonPropertyName("toDate")] public string? ToDate { get; set; }
+        [JsonPropertyName("resolution")] public string? Resolution { get; set; }
+    }
+}

--- a/DhanAlgoTrading/Models/DhanApi/HistoricalChartResponseDto.cs
+++ b/DhanAlgoTrading/Models/DhanApi/HistoricalChartResponseDto.cs
@@ -1,0 +1,19 @@
+using System.Text.Json.Serialization;
+
+namespace DhanAlgoTrading.Models.DhanApi
+{
+    public class HistoricalCandle
+    {
+        [JsonPropertyName("time")] public string? Time { get; set; }
+        [JsonPropertyName("open")] public decimal Open { get; set; }
+        [JsonPropertyName("high")] public decimal High { get; set; }
+        [JsonPropertyName("low")] public decimal Low { get; set; }
+        [JsonPropertyName("close")] public decimal Close { get; set; }
+        [JsonPropertyName("volume")] public int Volume { get; set; }
+    }
+
+    public class HistoricalChartResponseDto
+    {
+        [JsonPropertyName("candles")] public List<HistoricalCandle>? Candles { get; set; }
+    }
+}

--- a/DhanAlgoTrading/Models/DhanApi/HistoricalTradeDto.cs
+++ b/DhanAlgoTrading/Models/DhanApi/HistoricalTradeDto.cs
@@ -1,0 +1,14 @@
+using System.Text.Json.Serialization;
+
+namespace DhanAlgoTrading.Models.DhanApi
+{
+    public class HistoricalTradeDto
+    {
+        [JsonPropertyName("tradeDate")] public string? TradeDate { get; set; }
+        [JsonPropertyName("exchangeSegment")] public string? ExchangeSegment { get; set; }
+        [JsonPropertyName("securityId")] public string? SecurityId { get; set; }
+        [JsonPropertyName("transactionType")] public string? TransactionType { get; set; }
+        [JsonPropertyName("price")] public decimal Price { get; set; }
+        [JsonPropertyName("quantity")] public int Quantity { get; set; }
+    }
+}

--- a/DhanAlgoTrading/Models/DhanApi/KillSwitchResponseDto.cs
+++ b/DhanAlgoTrading/Models/DhanApi/KillSwitchResponseDto.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace DhanAlgoTrading.Models.DhanApi
+{
+    public class KillSwitchResponseDto
+    {
+        [JsonPropertyName("status")] public string? Status { get; set; }
+    }
+}

--- a/DhanAlgoTrading/Models/DhanApi/LedgerEntryDto.cs
+++ b/DhanAlgoTrading/Models/DhanApi/LedgerEntryDto.cs
@@ -1,0 +1,13 @@
+using System.Text.Json.Serialization;
+
+namespace DhanAlgoTrading.Models.DhanApi
+{
+    public class LedgerEntryDto
+    {
+        [JsonPropertyName("date")] public string? Date { get; set; }
+        [JsonPropertyName("description")] public string? Description { get; set; }
+        [JsonPropertyName("debit")] public decimal Debit { get; set; }
+        [JsonPropertyName("credit")] public decimal Credit { get; set; }
+        [JsonPropertyName("balance")] public decimal Balance { get; set; }
+    }
+}

--- a/DhanAlgoTrading/Services/DhanService.cs
+++ b/DhanAlgoTrading/Services/DhanService.cs
@@ -1343,6 +1343,165 @@ namespace DhanAlgoTrading.Api.Services
                 return false;
             }
         }
+
+        // ------------------- Newly Added APIs -------------------
+        public async Task<IEnumerable<ForeverOrderDto>> GetForeverOrdersAsync()
+        {
+            var requestUri = "/v2/forever/all";
+            try
+            {
+                var orders = await _httpClient.GetFromJsonAsync<List<ForeverOrderDto>>(requestUri, _jsonSerializerOptions);
+                return orders ?? new List<ForeverOrderDto>();
+            }
+            catch (Exception ex) when (ex is HttpRequestException || ex is JsonException)
+            {
+                _logger.LogError(ex, "Error fetching forever orders");
+                return Enumerable.Empty<ForeverOrderDto>();
+            }
+        }
+
+        public async Task<OrderResponseDto?> PlaceForeverOrderAsync(ForeverOrderRequestDto request)
+        {
+            if (request == null)
+            {
+                _logger.LogWarning("PlaceForeverOrderAsync called with null request");
+                return null;
+            }
+            var requestUri = "/v2/forever";
+            try
+            {
+                var response = await _httpClient.PostAsJsonAsync(requestUri, request, _jsonSerializerOptions);
+                return await response.Content.ReadFromJsonAsync<OrderResponseDto>(_jsonSerializerOptions);
+            }
+            catch (Exception ex) when (ex is HttpRequestException || ex is JsonException)
+            {
+                _logger.LogError(ex, "Error placing forever order");
+                return null;
+            }
+        }
+
+        public async Task<bool> CancelForeverOrderAsync(string orderId)
+        {
+            if (string.IsNullOrWhiteSpace(orderId)) return false;
+            var requestUri = $"/v2/forever/{WebUtility.UrlEncode(orderId)}";
+            try
+            {
+                var resp = await _httpClient.DeleteAsync(requestUri);
+                return resp.IsSuccessStatusCode;
+            }
+            catch (HttpRequestException ex)
+            {
+                _logger.LogError(ex, "Error cancelling forever order {OrderId}", orderId);
+                return false;
+            }
+        }
+
+        public async Task<EdisTpinResponseDto?> GenerateEdisTpinAsync()
+        {
+            var requestUri = "/v2/edis/tpin";
+            try
+            {
+                return await _httpClient.GetFromJsonAsync<EdisTpinResponseDto>(requestUri, _jsonSerializerOptions);
+            }
+            catch (Exception ex) when (ex is HttpRequestException || ex is JsonException)
+            {
+                _logger.LogError(ex, "Error generating EDIS TPIN");
+                return null;
+            }
+        }
+
+        public async Task<bool> SubmitEdisFormAsync(EdisFormRequestDto form)
+        {
+            if (form == null) return false;
+            var requestUri = "/v2/edis/form";
+            try
+            {
+                var resp = await _httpClient.PostAsJsonAsync(requestUri, form, _jsonSerializerOptions);
+                return resp.IsSuccessStatusCode || resp.StatusCode == HttpStatusCode.Accepted;
+            }
+            catch (HttpRequestException ex)
+            {
+                _logger.LogError(ex, "Error submitting EDIS form");
+                return false;
+            }
+        }
+
+        public async Task<EdisInquireResponseDto?> InquireEdisAsync(string isin)
+        {
+            if (string.IsNullOrWhiteSpace(isin)) return null;
+            var requestUri = $"/v2/edis/inquire/{WebUtility.UrlEncode(isin)}";
+            try
+            {
+                return await _httpClient.GetFromJsonAsync<EdisInquireResponseDto>(requestUri, _jsonSerializerOptions);
+            }
+            catch (Exception ex) when (ex is HttpRequestException || ex is JsonException)
+            {
+                _logger.LogError(ex, "Error inquiring EDIS for {Isin}", isin);
+                return null;
+            }
+        }
+
+        public async Task<KillSwitchResponseDto?> SetKillSwitchAsync(string status)
+        {
+            if (string.IsNullOrWhiteSpace(status)) return null;
+            var requestUri = $"/v2/killswitch?killSwitchStatus={WebUtility.UrlEncode(status)}";
+            try
+            {
+                var resp = await _httpClient.PostAsync(requestUri, null);
+                return await resp.Content.ReadFromJsonAsync<KillSwitchResponseDto>(_jsonSerializerOptions);
+            }
+            catch (Exception ex) when (ex is HttpRequestException || ex is JsonException)
+            {
+                _logger.LogError(ex, "Error setting kill switch status {Status}", status);
+                return null;
+            }
+        }
+
+        public async Task<IEnumerable<LedgerEntryDto>> GetLedgerAsync()
+        {
+            var requestUri = "/v2/ledger";
+            try
+            {
+                var ledger = await _httpClient.GetFromJsonAsync<List<LedgerEntryDto>>(requestUri, _jsonSerializerOptions);
+                return ledger ?? new List<LedgerEntryDto>();
+            }
+            catch (Exception ex) when (ex is HttpRequestException || ex is JsonException)
+            {
+                _logger.LogError(ex, "Error fetching ledger");
+                return Enumerable.Empty<LedgerEntryDto>();
+            }
+        }
+
+        public async Task<IEnumerable<HistoricalTradeDto>> GetHistoricalTradesAsync(string fromDate, string toDate, int page)
+        {
+            var requestUri = $"/v2/trades/{fromDate}/{toDate}/{page}";
+            try
+            {
+                var trades = await _httpClient.GetFromJsonAsync<List<HistoricalTradeDto>>(requestUri, _jsonSerializerOptions);
+                return trades ?? new List<HistoricalTradeDto>();
+            }
+            catch (Exception ex) when (ex is HttpRequestException || ex is JsonException)
+            {
+                _logger.LogError(ex, "Error fetching historical trades");
+                return Enumerable.Empty<HistoricalTradeDto>();
+            }
+        }
+
+        public async Task<HistoricalChartResponseDto?> GetHistoricalChartAsync(HistoricalChartRequestDto request)
+        {
+            if (request == null) return null;
+            var requestUri = "/v2/charts/historical";
+            try
+            {
+                var resp = await _httpClient.PostAsJsonAsync(requestUri, request, _jsonSerializerOptions);
+                return await resp.Content.ReadFromJsonAsync<HistoricalChartResponseDto>(_jsonSerializerOptions);
+            }
+            catch (Exception ex) when (ex is HttpRequestException || ex is JsonException)
+            {
+                _logger.LogError(ex, "Error fetching historical chart");
+                return null;
+            }
+        }
     }
 
 }

--- a/DhanAlgoTrading/Services/IDhanService.cs
+++ b/DhanAlgoTrading/Services/IDhanService.cs
@@ -34,6 +34,21 @@ namespace DhanAlgoTrading.Services
         Task<OrderDataDto?> GetOrderByCorrelationIdAsync(string correlationId);
         Task<bool> ConvertPositionAsync(ConvertPositionRequestDto convertRequest);
 
+        // Missing APIs implemented now
+        Task<IEnumerable<ForeverOrderDto>> GetForeverOrdersAsync();
+        Task<OrderResponseDto?> PlaceForeverOrderAsync(ForeverOrderRequestDto request);
+        Task<bool> CancelForeverOrderAsync(string orderId);
+
+        Task<EdisTpinResponseDto?> GenerateEdisTpinAsync();
+        Task<bool> SubmitEdisFormAsync(EdisFormRequestDto form);
+        Task<EdisInquireResponseDto?> InquireEdisAsync(string isin);
+
+        Task<KillSwitchResponseDto?> SetKillSwitchAsync(string status);
+
+        Task<IEnumerable<LedgerEntryDto>> GetLedgerAsync();
+        Task<IEnumerable<HistoricalTradeDto>> GetHistoricalTradesAsync(string fromDate, string toDate, int page);
+        Task<HistoricalChartResponseDto?> GetHistoricalChartAsync(HistoricalChartRequestDto request);
+
 
 
     }


### PR DESCRIPTION
## Summary
- implement additional Dhan API methods (forever orders, EDIS, kill switch, ledger, historical data)
- expose new methods in `IDhanService`
- create DTO classes for the new endpoints
- update tests with coverage for new features and stub service

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68404a3097f08321a3ada8f61091b6b0